### PR TITLE
Auto-refresh buttons on setting changes & startup

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -38,14 +38,13 @@ export default class TopBarButtonsSettingTab extends PluginSettingTab {
         });
 
         containerEl.createEl('p', {
-            text: 'The buttons are added in the order in which they are shown here. This only takes effect after a reload.',
+            text: 'The buttons are added in the order in which they are shown here.',
         });
 
         new Setting(containerEl)
             .setName('Show buttons on desktop')
             .setDesc(
-                'By default, the buttons will only be shown in Obsidian Mobile. \
-                It requires a reload after being toggled to take effect.'
+                'By default, the buttons will only be shown in Obsidian Mobile.'
             )
             .addToggle((toggle) => {
                 toggle.setValue(settings.desktop).onChange(async (state) => {
@@ -77,7 +76,7 @@ export default class TopBarButtonsSettingTab extends PluginSettingTab {
             new Setting(containerEl)
                 .setName('Pane Relief count')
                 .setDesc(
-                    'Enable to show the pane relief count next to back/forward buttons. Needs a reload to take effect.'
+                    'Enable to show the pane relief history count next to back/forward buttons.'
                 )
                 .addToggle((toggle) => {
                     toggle


### PR DESCRIPTION
This change automatically updates all panes with buttons whenever the settings are changed or the plugin starts up.  It also lets Pane Relief know when the button settings are changed so PR can refresh their titles if needed.

Unfortunately, it doesn't support workspaces yet: if you change workspaces the items will load one at a time as they did before.  But in 0.15.3 you can change the settings and watch them take effect immediately in any other open windows, so no more "this requires a reload` for any of the settings.